### PR TITLE
Allow parsing a Tagged<T> if there is no tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0.14", default-features = false }
 
 [dev-dependencies]
 serde_derive = { version = "1.0.14", default-features = false }
+serde_json = "1.0.42"
 
 [features]
 default = ["std"]

--- a/examples/tags.rs
+++ b/examples/tags.rs
@@ -17,9 +17,13 @@ impl Serialize for Date {
 
 impl<'de> Deserialize<'de> for Date {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Tagged::<String>::deserialize(deserializer)?
-            .unwrap_if_tag::<D>(0)
-            .map(Date)
+        let tagged = Tagged::<String>::deserialize(deserializer)?;
+        match tagged.tag {
+            Some(0) => Ok(Date(tagged.value)),
+            Some(_) => Err(serde::de::Error::custom("unexpected tag")),
+            // allow deserialization even if there is no tag. Allows roundtrip via other formats such as json
+            None => Ok(Date(tagged.value)),
+        }
     }
 }
 
@@ -34,9 +38,12 @@ impl Serialize for Uri {
 }
 impl<'de> Deserialize<'de> for Uri {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Tagged::<String>::deserialize(deserializer)?
-            .unwrap_if_tag::<D>(32)
-            .map(Uri)
+        let tagged = Tagged::<String>::deserialize(deserializer)?;
+        match tagged.tag {
+            Some(0) => Ok(Uri(tagged.value)),
+            Some(_) => Err(serde::de::Error::custom("unexpected tag")),
+            None => Ok(Uri(tagged.value)),
+        }
     }
 }
 
@@ -69,6 +76,11 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // check that the roundtrip was successful
     assert_eq!(value1, value2);
+    assert_eq!(bookmark, result);
+
+    // check that going via a format that does not support tags does work
+    let json = serde_json::to_vec(&bookmark)?;
+    let result: Bookmark = serde_json::from_slice(&json)?;
     assert_eq!(bookmark, result);
     Ok(())
 }

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -1,5 +1,10 @@
 //! Support for cbor tags
-use core::{fmt, marker};
+use core::fmt;
+use core::marker::PhantomData;
+use serde::de::{
+    Deserialize, Deserializer, EnumAccess, IntoDeserializer, MapAccess, SeqAccess, Visitor,
+};
+use serde::forward_to_deserialize_any;
 use serde::ser::{Serialize, Serializer};
 
 /// signals that a newtype is from a CBOR tag
@@ -20,18 +25,6 @@ impl<T> Tagged<T> {
     pub fn new(tag: Option<u64>, value: T) -> Self {
         Self { tag, value }
     }
-
-    /// Get the inner value if the cbor tag has the expected value
-    pub fn unwrap_if_tag<'de, D: serde::de::Deserializer<'de>>(
-        self,
-        expected_tag: u64,
-    ) -> Result<T, D::Error> {
-        match self.tag {
-            Some(tag) if tag == expected_tag => Ok(self.value),
-            Some(_) => Err(serde::de::Error::custom("unexpected cbor tag")),
-            None => Err(serde::de::Error::custom("missing cbor tag")),
-        }
-    }
 }
 
 impl<T: Serialize> Serialize for Tagged<T> {
@@ -43,27 +36,129 @@ impl<T: Serialize> Serialize for Tagged<T> {
     }
 }
 
+fn untagged<T>(value: T) -> Tagged<T> {
+    Tagged::new(None, value)
+}
+
+macro_rules! delegate {
+    ($name: ident, $type: ty) => {
+        fn $name<E: serde::de::Error>(self, v: $type) -> Result<Self::Value, E>
+        {
+            T::deserialize(v.into_deserializer()).map(untagged)
+        }
+    };
+}
+
+struct EnumDeserializer<A>(A);
+
+impl<'de, A> Deserializer<'de> for EnumDeserializer<A>
+where
+    A: EnumAccess<'de>,
+{
+    type Error = A::Error;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_enum(self.0)
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+struct NoneDeserializer<E>(core::marker::PhantomData<E>);
+
+impl<'de, E> Deserializer<'de> for NoneDeserializer<E>
+where
+    E: serde::de::Error,
+{
+    type Error = E;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_none()
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+/// A visitor that intercepts *just* visit_newtype_struct and passes through everything else.
+struct MaybeTaggedVisitor<T>(core::marker::PhantomData<T>);
+
+impl<'de, T: Deserialize<'de>> Visitor<'de> for MaybeTaggedVisitor<T> {
+    type Value = Tagged<T>;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("a cbor tag newtype")
+    }
+
+    delegate!(visit_bool, bool);
+
+    delegate!(visit_i8, i8);
+    delegate!(visit_i16, i16);
+    delegate!(visit_i32, i32);
+    delegate!(visit_i64, i64);
+
+    delegate!(visit_u8, u8);
+    delegate!(visit_u16, u16);
+    delegate!(visit_u32, u32);
+    delegate!(visit_u64, u64);
+
+    delegate!(visit_f32, f32);
+    delegate!(visit_f64, f64);
+
+    delegate!(visit_char, char);
+    delegate!(visit_str, &str);
+    delegate!(visit_borrowed_str, &'de str);
+    delegate!(visit_string, String);
+
+    // delegate!(visit_bytes, &[u8]);
+    delegate!(visit_byte_buf, Vec<u8>);
+    fn visit_borrowed_bytes<E: serde::de::Error>(self, value: &'de [u8]) -> Result<Self::Value, E> {
+        T::deserialize(serde::de::value::BorrowedBytesDeserializer::new(value)).map(untagged)
+    }
+
+    fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+        T::deserialize(().into_deserializer()).map(untagged)
+    }
+
+    fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+        T::deserialize(NoneDeserializer(core::marker::PhantomData)).map(untagged)
+    }
+
+    fn visit_some<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        T::deserialize(deserializer).map(untagged)
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, seq: A) -> Result<Self::Value, A::Error> {
+        T::deserialize(serde::de::value::SeqAccessDeserializer::new(seq)).map(untagged)
+    }
+
+    fn visit_map<V: MapAccess<'de>>(self, map: V) -> Result<Self::Value, V::Error> {
+        T::deserialize(serde::de::value::MapAccessDeserializer::new(map)).map(untagged)
+    }
+
+    fn visit_enum<A: EnumAccess<'de>>(self, data: A) -> Result<Self::Value, A::Error> {
+        T::deserialize(EnumDeserializer(data)).map(untagged)
+    }
+
+    fn visit_newtype_struct<D: serde::Deserializer<'de>>(
+        self,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error> {
+        let t = get_tag();
+        T::deserialize(deserializer).map(|v| Tagged::new(t, v))
+    }
+}
+
 impl<'de, T: serde::de::Deserialize<'de>> serde::de::Deserialize<'de> for Tagged<T> {
     fn deserialize<D: serde::de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        struct ValueVisitor<T>(marker::PhantomData<T>);
-
-        impl<'de, T: serde::de::Deserialize<'de>> serde::de::Visitor<'de> for ValueVisitor<T> {
-            type Value = Tagged<T>;
-
-            fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-                fmt.write_str("a cbor tag newtype")
-            }
-
-            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                let t = get_tag();
-                T::deserialize(deserializer).map(|v| Tagged::new(t, v))
-            }
-        }
-
-        deserializer.deserialize_any(ValueVisitor::<T>(marker::PhantomData))
+        deserializer.deserialize_any(MaybeTaggedVisitor::<T>(PhantomData))
     }
 }
 


### PR DESCRIPTION
You can always reject it later, but this gives the option to have permissive parsing to allow e.g. json roundtrips